### PR TITLE
Do not add trailing spaces at the end of lines

### DIFF
--- a/pretty.go
+++ b/pretty.go
@@ -186,7 +186,7 @@ func appendPrettyObject(buf, json []byte, i int, open, close byte, pretty bool, 
 		if open == '[' || json[i] == '"' {
 			if n > 0 {
 				buf = append(buf, ',')
-				if width != -1 {
+				if width != -1 && open == '[' {
 					buf = append(buf, ' ')
 				}
 			}

--- a/pretty_test.go
+++ b/pretty_test.go
@@ -367,11 +367,11 @@ func TestColor(t *testing.T) {
 "obj":{"key1":null,"ar`+"\x1B[36m"+`Cyanr2":[1,2,3,"123","456"]}}
 	`)), nil)
 	if string(res) != `{
-  [94m"hello"[0m: [92m"world"[0m, 
-  [94m"what"[0m: [93m123[0m, 
-  [94m"arr"[0m: [[92m"1"[0m, [92m"2"[0m, [93m1[0m, [93m2[0m, [96mtrue[0m, [96mfalse[0m, [91mnull[0m], 
+  [94m"hello"[0m: [92m"world"[0m,
+  [94m"what"[0m: [93m123[0m,
+  [94m"arr"[0m: [[92m"1"[0m, [92m"2"[0m, [93m1[0m, [93m2[0m, [96mtrue[0m, [96mfalse[0m, [91mnull[0m],
   [94m"obj"[0m: {
-    [94m"key1"[0m: [91mnull[0m, 
+    [94m"key1"[0m: [91mnull[0m,
     [94m"ar\u001b[36mCyanr2"[0m: [[93m1[0m, [93m2[0m, [93m3[0m, [92m"123"[0m, [92m"456"[0m]
   }
 }


### PR DESCRIPTION
Unnecessary trailing spaces were being added at the end of lines with commas, due to shared logic for adding spaces between array elements. Updated test case to account for change:
```
$ go test -cover
PASS
coverage: 96.5% of statements
ok  	github.com/tidwall/pretty	0.516s
```