### PR TITLE
Reduce indexing and use switch statement in appendPrettyAny

### DIFF
--- a/pretty.go
+++ b/pretty.go
@@ -86,22 +86,15 @@ func ugly(dst, src []byte) []byte {
 
 func appendPrettyAny(buf, json []byte, i int, pretty bool, width int, prefix, indent string, sortkeys bool, tabs, nl, max int) ([]byte, int, int, bool) {
 	for ; i < len(json); i++ {
-		if json[i] <= ' ' {
-			continue
-		}
-		if json[i] == '"' {
-			return appendPrettyString(buf, json, i, nl)
-		}
-		if (json[i] >= '0' && json[i] <= '9') || json[i] == '-' {
-			return appendPrettyNumber(buf, json, i, nl)
-		}
-		if json[i] == '{' {
-			return appendPrettyObject(buf, json, i, '{', '}', pretty, width, prefix, indent, sortkeys, tabs, nl, max)
-		}
-		if json[i] == '[' {
-			return appendPrettyObject(buf, json, i, '[', ']', pretty, width, prefix, indent, sortkeys, tabs, nl, max)
-		}
 		switch json[i] {
+		case '"':
+			return appendPrettyString(buf, json, i, nl)
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-':
+			return appendPrettyNumber(buf, json, i, nl)
+		case '{':
+			return appendPrettyObject(buf, json, i, '{', '}', pretty, width, prefix, indent, sortkeys, tabs, nl, max)
+		case '[':
+			return appendPrettyObject(buf, json, i, '[', ']', pretty, width, prefix, indent, sortkeys, tabs, nl, max)
 		case 't':
 			return append(buf, 't', 'r', 'u', 'e'), i + 4, nl, true
 		case 'f':

--- a/pretty_test.go
+++ b/pretty_test.go
@@ -38,7 +38,7 @@ var example1 = []byte(`
 	],
 	"values2": {},
 	"values3": [],
-	"deep": {"deep":{"deep":[1,2,3,4,5]}}
+	"deep": {"deep":{"deep":[0,1,2,3,4,5,6,7,8,9]}}
 }
 `)
 


### PR DESCRIPTION
I noticed that some code includes string indexing for each conditional statements. I believe it's faster to reduce indexing to once in a loop and let the compiler optimize the switch statement (like [CL26770](https://go-review.googlesource.com/c/go/+/26770)).